### PR TITLE
update aws to 0.9.4 so that it can use newer conduit

### DIFF
--- a/aws-ec2.cabal
+++ b/aws-ec2.cabal
@@ -110,7 +110,7 @@ library
     , http-conduit
     , conduit-extra
     , xml-conduit
-    , aws >= 0.9.3
+    , aws >= 0.9.4
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -123,7 +123,7 @@ executable put-metric
     , bytestring
     , text
     , optparse-applicative
-    , aws >= 0.9.3
+    , aws >= 0.9.4
     , aws-ec2
 
   hs-source-dirs:      cmd
@@ -138,7 +138,7 @@ executable run-inst
     , bytestring
     , text
     , optparse-applicative
-    , aws >= 0.9.3
+    , aws >= 0.9.4
     , aws-ec2
     , yaml
     , vector

--- a/aws.nix
+++ b/aws.nix
@@ -7,8 +7,8 @@
 
 cabal.mkDerivation (self: {
   pname = "aws";
-  version = "0.9.3";
-  sha256 = "11g8i6kfq7n1v5nvj8bkhrgsiyzfz0vwk4lh8sljnfd5pyjawx7h";
+  version = "0.9.4";
+  sha256 = "1039db933612e3eb51f232b3875eb555c688530227349a9b50c4805b6cf3376f";
   isLibrary = true;
   isExecutable = true;
   buildDepends = [


### PR DESCRIPTION
conduit 1.1 is no longer available in nixpkgs
