### PR TITLE
Pass CPP header macros to the pre-processor via '-optP'.

### DIFF
--- a/aws-ec2.cabal
+++ b/aws-ec2.cabal
@@ -118,7 +118,7 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, TemplateHaskell, CPP
-  cpp-options:         --include=include/config.h
+  ghc-options:         -optP --include=include/config.h
 
 executable put-metric
   main-is: put-metric.hs


### PR DESCRIPTION
..rather than `cpp-options`, as before. This fixed `nix-build` for me,
which prior to this patch had been failing:

```
[57 of 59] Compiling Aws.Elb          ( src/Aws/Elb.hs,
dist/build/Aws/Elb.o )
[58 of 59] Compiling Aws.Elb.Commands.CreateAppCookieStickinessPolicy
( src/Aws/Elb/Commands/CreateAppCookieStickinessPolicy.hs,
dist/build/Aws/Elb/Commands/CreateAppCookieStickinessPolicy.o )
[59 of 59] Compiling Aws.Canonical    ( src/Aws/Canonical.hs,
dist/build/Aws/Canonical.o )
In-place registering aws-ec2-0.3.1...
Preprocessing executable 'put-metric' for aws-ec2-0.3.1...
[1 of 1] Compiling Main             ( cmd/put-metric.hs,
dist/build/put-metric/put-metric-tmp/Main.dyn_o )
Linking dist/build/put-metric/put-metric ...
Preprocessing executable 'run-inst' for aws-ec2-0.3.1...
[1 of 1] Compiling Main             ( cmd/run-inst.hs,
dist/build/run-inst/run-inst-tmp/Main.dyn_o )
Linking dist/build/run-inst/run-inst ...
Running Haddock for aws-ec2-0.3.1...
Running hscolour for aws-ec2-0.3.1...
Preprocessing library aws-ec2-0.3.1...
Preprocessing executable 'put-metric' for aws-ec2-0.3.1...
Preprocessing executable 'run-inst' for aws-ec2-0.3.1...
Preprocessing library aws-ec2-0.3.1...
ghc: unrecognised flag: --include=include/config.h

Usage: For basic information, try the `--help' option.
```

I'm not sure how that munging originally arose. :disappointed: 