### PR TITLE
Added support for FromJSON response objects

### DIFF
--- a/aws-ec2.cabal
+++ b/aws-ec2.cabal
@@ -108,6 +108,7 @@ library
     , vector
     , scientific
 
+    , exceptions
     , resourcet
     , byteable
     , cryptohash

--- a/include/config.h
+++ b/include/config.h
@@ -6,9 +6,9 @@
 
 #ifdef USE_TH
 #define QUERYVALUETRANSACTION(Name,Response) queryValueTransaction ''Name Response
-#define EC2VALUETRANSACTIONDEF(Name,NameStr,Tag,FilterKey) ec2ValueTransactionDef ''Name 'Name Tag FilterKey 
+#define EC2VALUETRANSACTIONDEF(Name,NameStr,Tag,FilterKey) ec2ValueTransactionDef ''Name 'Name Tag FilterKey
 #define EC2VALUETRANSACTION(Name,Response) ec2ValueTransaction ''Name Response
-#define ELBVALUETRANSACTIONDEF(Name,NameStr,Tag,FilterKey) elbValueTransactionDef ''Name 'Name Tag FilterKey 
+#define ELBVALUETRANSACTIONDEF(Name,NameStr,Tag,FilterKey) elbValueTransactionDef ''Name 'Name Tag FilterKey
 #define ELBVALUETRANSACTION(Name,Response) elbValueTransaction ''Name Response
 
 #else
@@ -17,7 +17,7 @@ instance ResponseConsumer Name Value where { \
   type ResponseMetadata Value = QueryMetadata; \
   responseConsumer _v \
     = (queryResponseConsumer \
-       $ (valueConsumer Response id)) }; \
+       $ (valueConsumer Response fromJSONConsumer)) }; \
 instance Transaction Name Value
 
 #define EC2VALUETRANSACTIONDEF(Name,NameStr,Tag,FilterKey) \
@@ -32,7 +32,7 @@ instance ResponseConsumer Name Value where { \
   responseConsumer _v \
     = (queryResponseConsumer \
        $ (valueConsumerOpt \
-            (XMLValueOptions "item") Tag id)) } ;\
+            (XMLValueOptions "item") Tag fromJSONConsumer)) } ;\
 instance Transaction Name Value
 
 #define EC2VALUETRANSACTION(Name,Response) \
@@ -40,7 +40,7 @@ instance ResponseConsumer Name Value where { \
   type ResponseMetadata Value = QueryMetadata ; \
   responseConsumer _v \
     = (queryResponseConsumer \
-       $ (valueConsumer (Response) id)) } ; \
+       $ (valueConsumer (Response) fromJSONConsumer)) } ; \
 instance Transaction Name Value
 
 #define ELBVALUETRANSACTIONDEF(Name,NameStr,Tag,FilterKey) \
@@ -55,7 +55,7 @@ instance ResponseConsumer Name Value where { \
   responseConsumer _ \
     = (queryResponseConsumer \
        $ (valueConsumerOpt \
-            (XMLValueOptions "member") Tag id)) }; \
+            (XMLValueOptions "member") Tag fromJSONConsumer)) }; \
 instance Transaction Name Value
 
 #define ELBVALUETRANSACTION(Name,Response) \
@@ -64,7 +64,7 @@ instance ResponseConsumer Name Value where { \
   responseConsumer _v \
     = (queryResponseConsumer \
        $ (valueConsumerOpt \
-            (XMLValueOptions "member") Response id)) }; \
+            (XMLValueOptions "member") Response fromJSONConsumer)) }; \
 instance Transaction Name Value
 
 #endif

--- a/src/Aws/Elb/Commands/DescribeLoadBalancerPolicyTypes.hs
+++ b/src/Aws/Elb/Commands/DescribeLoadBalancerPolicyTypes.hs
@@ -31,6 +31,6 @@ instance ResponseConsumer DescribeLoadBalancerPolicyTypes Value where
     responseConsumer ListLoadBalancerPolicyTypes = queryResponseConsumer $ \cu -> do
       let cu' = cu $.// Cu.laxElement "PolicyTypeName" &| (toValue (XMLValueOptions "item") . Cu.node)
       return $ Array $ V.fromList cu'
-    responseConsumer (DescribeLoadBalancerPolicyTypes _) = queryResponseConsumer $ valueConsumerOpt (XMLValueOptions "member") "DescribeLoadBalancerPolicyTypesResult" id
+    responseConsumer (DescribeLoadBalancerPolicyTypes _) = queryResponseConsumer $ valueConsumerOpt (XMLValueOptions "member") "DescribeLoadBalancerPolicyTypesResult" fromJSONConsumer
 
 instance Transaction DescribeLoadBalancerPolicyTypes Value

--- a/src/Aws/Elb/TH.hs
+++ b/src/Aws/Elb/TH.hs
@@ -34,7 +34,7 @@ elbValueTransaction :: Name -> String -> DecsQ
 elbValueTransaction ty tag = [d|
                   instance ResponseConsumer $(conT ty) Value where
                       type ResponseMetadata Value = QueryMetadata
-                      responseConsumer _ = queryResponseConsumer $ valueConsumerOpt (XMLValueOptions "member") $(stringE tag) id
+                      responseConsumer _ = queryResponseConsumer $ valueConsumerOpt (XMLValueOptions "member") $(stringE tag) fromJSONConsumer
 
                   instance Transaction $(conT ty) Value
                   |]

--- a/src/Aws/Query.hs
+++ b/src/Aws/Query.hs
@@ -97,9 +97,12 @@ instance Monoid QueryMetadata where
     mempty = QueryMetadata Nothing
     (QueryMetadata r1) `mappend` (QueryMetadata r2) = QueryMetadata (r1 `mplus` r2)
 
-data ConsumerError = ConsumerError String deriving (Show, Typeable)
+data ConsumeError = ConsumeError String deriving (Typeable)
 
-instance C.Exception ConsumerError
+instance C.Exception ConsumeError
+
+instance Show ConsumeError where
+  show (ConsumeError e) = e
 
 querySignQuery :: HTTP.Query -> QueryData -> SignatureData -> SignedQuery
 querySignQuery query QueryData{..} sd
@@ -211,7 +214,9 @@ fromJSONConsumer :: FromJSON a => Value -> Response QueryMetadata a
 fromJSONConsumer value =
   case fromJSON value of
       Error e -> throwM $
-        ConsumerError $ "Error consuming Value: " ++ e
+        ConsumeError $ "ConsumeError: " ++ e ++
+                       "\nError occured while consuming the following Value:\n" ++
+                       show value
       Success result -> return result
 
 valueConsumer :: Text -> (Value -> Response QueryMetadata a) -> Cu.Cursor -> Response QueryMetadata a

--- a/src/Aws/Query/TH.hs
+++ b/src/Aws/Query/TH.hs
@@ -44,7 +44,7 @@ queryValueTransactionDef ty cons tag signF version item filterKey = do
 
                   instance ResponseConsumer $(conT ty) Value where
                       type ResponseMetadata Value = QueryMetadata
-                      responseConsumer _ = queryResponseConsumer $ valueConsumerOpt (XMLValueOptions $(stringE item)) $(stringE tag) id
+                      responseConsumer _ = queryResponseConsumer $ valueConsumerOpt (XMLValueOptions $(stringE item)) $(stringE tag) fromJSONConsumer
 
                   instance Transaction $(conT ty) Value
                   |]
@@ -53,7 +53,7 @@ queryValueTransaction :: Name -> String -> DecsQ
 queryValueTransaction ty tag = [d|
                   instance ResponseConsumer $(conT ty) Value where
                       type ResponseMetadata Value = QueryMetadata
-                      responseConsumer _ = queryResponseConsumer $ valueConsumer $(stringE tag) id
+                      responseConsumer _ = queryResponseConsumer $ valueConsumer $(stringE tag) fromJSONConsumer
 
                   instance Transaction $(conT ty) Value
                   |]

--- a/src/Aws/Query/TH.hs
+++ b/src/Aws/Query/TH.hs
@@ -13,7 +13,6 @@ module Aws.Query.TH (
 , module Aws.Query
 , Text
 , UTCTime
-, FromJSON
 #ifdef USE_TH
 , queryValueTransactionDef
 , queryValueTransaction
@@ -25,7 +24,6 @@ import Language.Haskell.TH.Lib
 import Language.Haskell.TH.Syntax
 
 import Data.Text (Text)
-import Data.Aeson.Types (FromJSON(..))
 import Data.Time.Clock (UTCTime)
 
 import Aws.Core


### PR DESCRIPTION
Added support to use any response types as long as they are an instance of `FromJSON`. If the `Value` can not be decoded into the `FromJSON` instance, a `ConsumeException` is thrown containing the decoding error message.

Currently, old code will remain compatible as `Values` are still returned. However, if per command response types are introduced, this would break existing code. @proger How do you feel about that?

An example of how I would introduce response type for `DescribeRegions`:

```
data Region = Region { regionEndpoint :: Text
                     , regionName :: Text}
                     deriving (Show, Generic)

instance FromJSON Region

data Regions = Regions [Region] deriving (Show, Generic)
instance FromJSON Regions

instance SignQuery DescribeRegions where
    type ServiceConfiguration DescribeRegions = QueryAPIConfiguration
    signQuery (DescribeRegions arg) = ec2SignQuery $ [ ("Action", qArg "DescribeRegions")
                                                   , defVersion
                                                   ] +++ enumerate "RegionName" arg qArg

instance ResponseConsumer DescribeRegions Regions where
    type ResponseMetadata Regions = QueryMetadata
    responseConsumer _ = queryResponseConsumer $ valueConsumerOpt (XMLValueOptions "item") "regionInfo" fromJSONConsumer

instance Transaction DescribeRegions Regions

instance AsMemoryResponse Regions where
    type MemoryResponse Regions = Regions
    loadToMemory = return
```
